### PR TITLE
Service Layer Functionality for Stream

### DIFF
--- a/protos/Backend.proto
+++ b/protos/Backend.proto
@@ -19,3 +19,9 @@ message Replies {
 message Followers {
   repeated string username = 1;
 }
+
+// structure to associate username with other users
+// to store users who are streaming certain hashtags
+message Streamers {
+  repeated string username = 1;
+}

--- a/service_layer_test.cc
+++ b/service_layer_test.cc
@@ -221,6 +221,59 @@ TEST(ServiceLayerFunctionalityTest, ValidParentID) {
   EXPECT_EQ(sl_func.valid_parent_id("5"), false);
 }
 
+TEST(ServiceLayerFunctionalityTest, Stream) {
+  ServiceLayerFunctionality sl_func(true);
+  sl_func.registeruser("jillian");
+  EXPECT_EQ(sl_func.user_exists("jillian"), true);
+  sl_func.startStream("jillian", "#Athenahacks");
+
+  Chirps chirps1 = sl_func.stream("jillian");
+  // stream should not initially return a chirp
+  EXPECT_EQ(chirps1.chirps_size(), 0);
+
+  Chirp *chirp1 = new Chirp();
+  std::string username1 = "krishna";
+  std::string text1 = "#Athenahacks";
+  std::string parent_id1 = "-1";
+  sl_func.chirp(chirp1, username1, text1, parent_id1);
+
+  chirps1 = sl_func.stream("jillian");
+  EXPECT_EQ(chirps1.chirps_size(), 1);
+  chirps1 = sl_func.stream("jillian");
+  EXPECT_EQ(chirps1.chirps_size(), 0);
+
+  sl_func.endStream("jillian", "#Athenahacks");
+  Chirp *chirp2 = new Chirp();
+  std::string username2 = "krishna";
+  std::string text2 = "#Athenahacks";
+  std::string parent_id2 = "-1";
+  sl_func.chirp(chirp2, username2, text2, parent_id2);
+  Chirps chirps2 = sl_func.stream("jillian");
+  EXPECT_EQ(chirps2.chirps_size(), 0);
+
+  delete chirp1;
+  delete chirp2;
+}
+TEST(ServiceLayerFunctionalityTest, StreamInvalid) {
+  ServiceLayerFunctionality sl_func(true);
+  sl_func.registeruser("jillian");
+  EXPECT_EQ(sl_func.user_exists("jillian"), true);
+  sl_func.startStream("jillian", "#Athenahacks");
+
+  Chirp *chirp1 = new Chirp();
+  std::string username1 = "krishna";
+  std::string text1 = "#Athenahacks2019";
+  std::string parent_id1 = "-1";
+  sl_func.chirp(chirp1, username1, text1, parent_id1);
+
+  Chirps chirps1 = sl_func.stream("jillian");
+  EXPECT_EQ(chirps1.chirps_size(), 0);
+
+  sl_func.endStream("jillian", "#Athenahacks");
+
+  delete chirp1;
+}
+
 int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/sl_functionality.cc
+++ b/sl_functionality.cc
@@ -107,6 +107,9 @@ Chirps ServiceLayerFunctionality::stream(const std::string& username) {
 
 void ServiceLayerFunctionality::startStream(const std::string& username, const std::string& hashtag) {
   std::lock_guard<std::mutex> lock(sl_func_mtx_);
+  if (hashtag.length() == 1 || hashtag.find("#")==std::string::npos) {
+    return;
+  }
   // Form streaming key for the given hashtag
   const std::string kStreamingKey = "streaming::" + hashtag;
   // Retrieve streamers from the key value store

--- a/sl_functionality.h
+++ b/sl_functionality.h
@@ -33,6 +33,7 @@ using chirp::ServiceLayer;
 using chirp::Chirps;
 using chirp::Replies;
 using chirp::Followers;
+using chirp::Streamers;
 
 #ifndef CHIRP_SL_FUNCTIONALITY_H
 #define CHIRP_SL_FUNCTIONALITY_H
@@ -55,6 +56,12 @@ class ServiceLayerFunctionality{
   std::vector<Chirp> read(const std::string& chirp_id);
   // return the current chirps broadcast to a user that is monitoring
   Chirps monitor(const std::string& username);
+  // return the current chirps broadcast to a user that is streaming
+  Chirps stream(const std::string& username);
+  // adds a user to the stream list for the given hashtag
+  void startStream(const std::string& username, const std::string& hashtag);
+  // removes a user from the stream list for the given hashtag
+  void endStream(const std::string& username, const std::string& hashtag);
   // clears monitor value so that monitored chirps are no longer broadcast to the follower
   void clear_monitor(const std::string& username);
   // check if user exists in key value store backend
@@ -74,6 +81,8 @@ class ServiceLayerFunctionality{
   void increment_chirp_count();
   // broadcast a chirp to all followers of the user who are monitoring
   void broadcast_chirp(const std::string& username, Chirp chirp);
+  // broadcast a chirp to all users who are streaming for a given hashtag
+  void stream_chirp(Chirp chirp, const std::string& hashtag);
   // client for keyvaluestore layer
   KeyValueClientInterface* client_;
   // mutex to lock sl for monitor and other functions


### PR DESCRIPTION
Added startStream to set up the streaming process for a user and endStream to clean it up when they are done. Also added a stream function to get the streamed chirps for a given user. Added stream_chirp to add newly created chirps to be streamed for users who are streaming on a given hashtag. Added tests.